### PR TITLE
Multiple Project Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ You now simply click the big green "Use this template" button to use a copy of t
 Alternatively, if you aren't a github user, you can download a zip (see Releases button) and start your own repository with that.
 
 Then see the [User Projects](https://chaste.cs.ox.ac.uk/trac/wiki/ChasteGuides/UserProjects) guide page on the Chaste wiki for more information.
+
+If you clone this repository, you should make sure to rename the template_project folder with your project name and run the 'setup_project.py' script to avoid conflicts if you have multiple projects.

--- a/setup_project.py
+++ b/setup_project.py
@@ -31,6 +31,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import os
+from functools import partial
 
 
 def find_and_replace(filename, old_string, new_string):
@@ -67,6 +68,10 @@ def ask_for_response(question):
         ask_for_response("Please respond with yes or no:")
 
 
+def append_to_file_name(text_to_append, file):
+    os.rename(file, file.replace('.', text_to_append + '.'))
+
+
 def main():
     # The absolute path to the project directory
     path_to_project = os.path.dirname(os.path.realpath(__file__))
@@ -78,6 +83,18 @@ def main():
     base_cmakelists = os.path.join(path_to_project, 'CMakeLists.txt')
     apps_cmakelists = os.path.join(path_to_project, 'apps', 'CMakeLists.txt')
     test_cmakelists = os.path.join(path_to_project, 'test', 'CMakeLists.txt')
+
+    # Files to append project name to - this avoids conflicts if mutliple projects are generated from the template project
+    files_requiring_append = [os.path.join(path_to_project, 'apps', 'src', 'ExampleApp.cpp'),
+                              os.path.join(path_to_project, 'src', 'Hello.cpp'),
+                              os.path.join(path_to_project, 'src', 'Hello.hpp'),
+                              os.path.join(path_to_project, 'test', 'TestHello.hpp')]
+
+    # Append project name to required files
+    append_project_name = partial(append_to_file_name, '_' + project_name)
+    for file in files_requiring_append:
+        append_project_name(file)
+
 
     # Perform the find-and-replace tasks to update the template project
     find_and_replace(base_cmakelists, 'chaste_do_project(template_project', 'chaste_do_project(' + project_name)

--- a/setup_project.py
+++ b/setup_project.py
@@ -106,12 +106,12 @@ def main():
     sanitized_name = sanitize_project_name(project_name)
    
     substitutions = { # These are very specific to avoid rewriting the printed out "Hello world" message
-        "TestHello": "TestHello" +  sanitized_name,
+        "TestHello": "TestHello_" +  sanitized_name,
         "HELLO": "HELLO_" + sanitized_name.upper(),
-        "Hello world(": "Hello" + sanitized_name + " world(",
-        "class Hello": "class Hello" + sanitized_name,
-        "Hello::": "Hello" + sanitized_name + "::",
-        "Hello(": "Hello" + sanitized_name + "("
+        "Hello world(": "Hello_" + sanitized_name + " world(",
+        "class Hello": "class Hello_" + sanitized_name,
+        "Hello::": "Hello_" + sanitized_name + "::",
+        "Hello(": "Hello_" + sanitized_name + "("
     }
     
     files_to_sub = appended_file_names + [str(os.path.join(path_to_project, 'test', 'ContinuousTestPack.txt'))]

--- a/setup_project.py
+++ b/setup_project.py
@@ -73,7 +73,7 @@ def append_to_file_name(text_to_append, file):
     new_name = file.replace('.', text_to_append + '.')
     os.rename(file, new_name)
     return new_name
-    
+
 
 # Converts a project name to something that will be valid to append to a C++ class name
 def sanitize_project_name(project_name):
@@ -104,24 +104,27 @@ def main():
 
     # Perform the find-and-replace tasks to update the template project source
     sanitized_name = sanitize_project_name(project_name)
-   
+
     substitutions = { # These are very specific to avoid rewriting the printed out "Hello world" message
-        "TestHello": "TestHello_" +  sanitized_name,
+        " TestHello": " TestHello_" +  sanitized_name,
+        "TestHello.hpp": "TestHello_" + project_name + ".hpp",
         "HELLO": "HELLO_" + sanitized_name.upper(),
         "Hello world(": "Hello_" + sanitized_name + " world(",
         "class Hello": "class Hello_" + sanitized_name,
         "Hello::": "Hello_" + sanitized_name + "::",
-        "Hello(": "Hello_" + sanitized_name + "("
+        "Hello(": "Hello_" + sanitized_name + "(",
+        "TestHello.hpp": "TestHello_" + project_name + ".hpp",
+        "Hello.hpp": "Hello_" + project_name + ".hpp"
     }
-    
+
     files_to_sub = appended_file_names + [str(os.path.join(path_to_project, 'test', 'ContinuousTestPack.txt'))]
 
     for file in files_to_sub:
         for old, new in substitutions.items():
             find_and_replace(file, old, new)
-     
 
-    # Perform the find-and-replace tasks to update the template project cmake   
+
+    # Perform the find-and-replace tasks to update the template project cmake
     find_and_replace(base_cmakelists, 'chaste_do_project(template_project', 'chaste_do_project(' + project_name)
     find_and_replace(apps_cmakelists, 'chaste_do_apps_project(template_project', 'chaste_do_apps_project(' + project_name)
     find_and_replace(test_cmakelists, 'chaste_do_test_project(template_project', 'chaste_do_test_project(' + project_name)

--- a/setup_project.py
+++ b/setup_project.py
@@ -68,8 +68,16 @@ def ask_for_response(question):
         ask_for_response("Please respond with yes or no:")
 
 
+# Appends text_to_append before the file extension
 def append_to_file_name(text_to_append, file):
-    os.rename(file, file.replace('.', text_to_append + '.'))
+    new_name = file.replace('.', text_to_append + '.')
+    os.rename(file, new_name)
+    return new_name
+    
+
+# Converts a project name to something that will be valid to append to a C++ class name
+def sanitize_project_name(project_name):
+    return ''.join(filter(lambda char: char.isalpha() or char.isnumeric(), project_name))
 
 
 def main():
@@ -92,11 +100,28 @@ def main():
 
     # Append project name to required files
     append_project_name = partial(append_to_file_name, '_' + project_name)
-    for file in files_requiring_append:
-        append_project_name(file)
+    appended_file_names = list(map(append_project_name, files_requiring_append))
 
+    # Perform the find-and-replace tasks to update the template project source
+    sanitized_name = sanitize_project_name(project_name)
+   
+    substitutions = { # These are very specific to avoid rewriting the printed out "Hello world" message
+        "TestHello": "TestHello" +  sanitized_name,
+        "HELLO": "HELLO_" + sanitized_name.upper(),
+        "Hello world(": "Hello" + sanitized_name + " world(",
+        "class Hello": "class Hello" + sanitized_name,
+        "Hello::": "Hello" + sanitized_name + "::",
+        "Hello(": "Hello" + sanitized_name + "("
+    }
+    
+    files_to_sub = appended_file_names + [str(os.path.join(path_to_project, 'test', 'ContinuousTestPack.txt'))]
 
-    # Perform the find-and-replace tasks to update the template project
+    for file in files_to_sub:
+        for old, new in substitutions.items():
+            find_and_replace(file, old, new)
+     
+
+    # Perform the find-and-replace tasks to update the template project cmake   
     find_and_replace(base_cmakelists, 'chaste_do_project(template_project', 'chaste_do_project(' + project_name)
     find_and_replace(apps_cmakelists, 'chaste_do_apps_project(template_project', 'chaste_do_apps_project(' + project_name)
     find_and_replace(test_cmakelists, 'chaste_do_test_project(template_project', 'chaste_do_test_project(' + project_name)


### PR DESCRIPTION
This PR adds support for multiple projects derived from the template_project. It updates the setup_project.py script to append the project name (this is the name of the containing folder) to the default file and class names.

The relevant tickets are [#2587](https://chaste.cs.ox.ac.uk/trac/ticket/2857) and [#3098](https://chaste.cs.ox.ac.uk/trac/ticket/3098) in the main repository